### PR TITLE
Add git commit info to build

### DIFF
--- a/Build/Make/make_000.gmk
+++ b/Build/Make/make_000.gmk
@@ -17,6 +17,22 @@ PATH_BIN        = $(CURDIR)/../Bin/target_x64
 
 MY_NUL         :=
 
+###############################################################################
+# Punctuation
+###############################################################################
+
+HASH           := \#
+$(HASH)        := \#
+
+DQUOTE         := \"
+$(DQUOTE)      := \"
+
+PERCENT        := \"
+$(PERCENT)     := \"
+
+DOLLAR         := $$
+$(DOLLAR)      := $$
+
 ifeq ($(TYP_OS),win)
 
 PATH_TOOLS = $(CURDIR)/../tools
@@ -37,6 +53,8 @@ SED             = $(PATH_TOOLS_UTIL)/bin/sed.exe
 
 MY_NUL         := NUL
 
+RULE_GIT_INFO  := $(ECHO) Git commit info unavailable
+
 endif
 
 ifeq ($(TYP_OS),unix)
@@ -48,10 +66,14 @@ READELF         = arm-none-eabi-readelf
 
 MAKE            = make
 ECHO            = echo
+GIT             = git
 RM              = rm
 MKDIR           = mkdir
 
 MY_NUL         := /dev/null
+
+RULE_GIT_INFO  := $(GIT) log -n 1 --pretty=format:$(DQUOTE)Current Used Branch/Commit: - $(PERCENT)d - $(PERCENT)H$(DQUOTE)
+RULE_GIT_INFO  := $(GIT) --version && $(ECHO) $(RULE_GIT_INFO) && $(RULE_GIT_INFO)
 
 endif
 
@@ -175,6 +197,9 @@ clean_prj :
 
 .PHONY : version
 version :
+	@$(ECHO) +++ print Git commit info
+	@-$(RULE_GIT_INFO)
+	@$(ECHO)
 	@$(ECHO) +++ print GNUmake version
 	@$(MAKE) --version
 	@$(ECHO)

--- a/Build/Make/make_000.gmk
+++ b/Build/Make/make_000.gmk
@@ -27,8 +27,8 @@ $(HASH)        := \#
 DQUOTE         := \"
 $(DQUOTE)      := \"
 
-PERCENT        := \"
-$(PERCENT)     := \"
+PERCENT        := \%
+$(PERCENT)     := \%
 
 DOLLAR         := $$
 $(DOLLAR)      := $$

--- a/Build/Make/make_000.gmk
+++ b/Build/Make/make_000.gmk
@@ -53,8 +53,6 @@ SED             = $(PATH_TOOLS_UTIL)/bin/sed.exe
 
 MY_NUL         := NUL
 
-RULE_GIT_INFO  := $(ECHO) Git commit info unavailable
-
 endif
 
 ifeq ($(TYP_OS),unix)
@@ -64,16 +62,13 @@ OBJCOPY         = arm-none-eabi-objcopy
 OBJDUMP         = arm-none-eabi-objdump
 READELF         = arm-none-eabi-readelf
 
-MAKE            = make
 ECHO            = echo
-GIT             = git
-RM              = rm
+MAKE            = make
 MKDIR           = mkdir
+RM              = rm
+SED             = sed
 
 MY_NUL         := /dev/null
-
-RULE_GIT_INFO  := $(GIT) log -n 1 --pretty=format:$(DQUOTE)Current Used Branch/Commit: - $(PERCENT)d - $(PERCENT)H$(DQUOTE)
-RULE_GIT_INFO  := $(GIT) --version && $(ECHO) $(RULE_GIT_INFO) && $(RULE_GIT_INFO)
 
 endif
 
@@ -197,9 +192,6 @@ clean_prj :
 
 .PHONY : version
 version :
-	@$(ECHO) +++ print Git commit info
-	@-$(RULE_GIT_INFO)
-	@$(ECHO)
 	@$(ECHO) +++ print GNUmake version
 	@$(MAKE) --version
 	@$(ECHO)
@@ -226,9 +218,9 @@ $(PATH_BIN)/target.elf : $(FILES_O)
 $(PATH_OBJ)/%.o : %.c
 	@-$(ECHO) +++ compile: $(subst \,/,$<) to $(subst \,/,$@)
 	@-$(CC) -x c -std=c11 $(CFLAGS) -c $< -o $(PATH_OBJ)/$(basename $(@F)).o 2> $(PATH_OBJ)/$(basename $(@F)).err
-	@-$(SED) -e 's|.h:\([0-9]*\),|.h(\1) :|' -e 's|:\([0-9]*\):|(\1) :|' $(PATH_OBJ)/$(basename $(@F)).err
+	@-$(SED) -e 's|:\([0-9]*\):|(\1) :|' $(PATH_OBJ)/$(basename $(@F)).err
 
 $(PATH_OBJ)/%.o : %.cpp
 	@-$(ECHO) +++ compile: $(subst \,/,$<) to $(subst \,/,$@)
-	@-$(CC) -x c++ -std=c++20 $(CPPFLAGS) -c $< -o $(PATH_OBJ)/$(basename $(@F)).o 2> $(PATH_OBJ)/$(basename $(@F)).err
-	@-$(SED) -e 's|.h:\([0-9]*\),|.h(\1) :|' -e 's|:\([0-9]*\):|(\1) :|' $(PATH_OBJ)/$(basename $(@F)).err
+	@-$(CC) -x c++ -std=c++17 $(CPPFLAGS) -c $< -o $(PATH_OBJ)/$(basename $(@F)).o 2> $(PATH_OBJ)/$(basename $(@F)).err
+	@-$(SED) -e 's|:\([0-9]*\):|(\1) :|' $(PATH_OBJ)/$(basename $(@F)).err

--- a/Build/build.sh
+++ b/Build/build.sh
@@ -4,6 +4,12 @@
 SCRIPT_PATH=$(readlink -f "$BASH_SOURCE")
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 
+cd ../..
+
+git log -n 1 --pretty=format:"Current Used Branch/Commit: - %d - %H"
+
+cd Build/VS
+
 build_command="make -f $SCRIPT_DIR/Make/make_000.gmk TYP_OS=unix $1"
 
 echo Executing Command: $build_command


### PR DESCRIPTION
Hi Amine @Chalandi I ended up putting the Git-commit-info into the controlling shell script of the build. The reason is because you need to change to the root directory of the repo for the Git command to work. Maybe there is a clever _shell_ way to get this to work in GNUmake but I did not find it in the hurry.

I also repaired a long-overdue correction, as the `sed` tool was actually missing in the LINUX build. Should be much better overall now.

See also [this sample info](https://github.com/Embedded-System-Lovers/teensy-4_nxp_iMXRT1062/actions/runs/5489687211/jobs/10004165146#step:4:6).